### PR TITLE
Optimize  PossibleIntersection and StablePriorityQueue

### DIFF
--- a/src/PolygonClipper/PolygonClipper.cs
+++ b/src/PolygonClipper/PolygonClipper.cs
@@ -122,7 +122,9 @@ public class PolygonClipper
         // Process all segments in the subject polygon
         Vertex min = new(double.PositiveInfinity);
         Vertex max = new(double.NegativeInfinity);
-        StablePriorityQueue<SweepEvent, SweepEventComparer> eventQueue = new(new SweepEventComparer());
+
+        int eventCount = (subject.GetVertexCount() + clipping.GetVertexCount()) * 2;
+        StablePriorityQueue<SweepEvent, SweepEventComparer> eventQueue = new(new SweepEventComparer(), eventCount);
         int contourId = 0;
         for (int i = 0; i < subject.ContourCount; i++)
         {

--- a/tests/PolygonClipper.Benchmarks/ClippingLibraryComparison.cs
+++ b/tests/PolygonClipper.Benchmarks/ClippingLibraryComparison.cs
@@ -23,6 +23,7 @@ namespace PolygonClipper.Benchmarks;
 /// of <c>PolygonClipper</c> in isolation.
 /// </para>
 /// </summary>
+[MemoryDiagnoser]
 public class ClippingLibraryComparison
 {
     private static readonly FeatureCollection Data = TestData.Generic.GetFeatureCollection("issue71.geojson");

--- a/tests/PolygonClipper.Benchmarks/ClippingLibraryComparison.cs
+++ b/tests/PolygonClipper.Benchmarks/ClippingLibraryComparison.cs
@@ -6,13 +6,23 @@
 using BenchmarkDotNet.Attributes;
 using Clipper2Lib;
 using GeoJSON.Text.Feature;
-using GeoJSON.Text.Geometry;
+using PolygonClipper.Tests;
 using PolygonClipper.Tests.TestCases;
-
-using GeoPolygon = GeoJSON.Text.Geometry.Polygon;
 
 namespace PolygonClipper.Benchmarks;
 
+/// <summary>
+/// <para>
+/// Benchmarks the performance of <c>PolygonClipper</c> against <c>Clipper2</c>
+/// for polygon union operations using a fixed input dataset.
+/// </para>
+/// <para>
+/// Note: Clipper2 produces an incorrect result for the test case used in this benchmark.
+/// As such, the Clipper2 timing is included for reference only and should not be considered
+/// a valid correctness comparison. This benchmark is intended to evaluate the performance
+/// of <c>PolygonClipper</c> in isolation.
+/// </para>
+/// </summary>
 public class ClippingLibraryComparison
 {
     private static readonly FeatureCollection Data = TestData.Generic.GetFeatureCollection("issue71.geojson");
@@ -25,17 +35,17 @@ public class ClippingLibraryComparison
     [GlobalSetup]
     public void Setup()
     {
-        (Polygon subject, Polygon clipping) = BuildPolygon();
+        (Polygon subject, Polygon clipping) = TestPolygonUtilities.BuildPolygon(Data);
         this.subject = subject;
         this.clipping = clipping;
 
-        (PathsD subject2, PathsD clipping2) = BuildPolygon2();
+        (PathsD subject2, PathsD clipping2) = TestPolygonUtilities.BuildClipper2Polygon(Data);
         this.subject2 = subject2;
         this.clipping2 = clipping2;
     }
 
     [Benchmark]
-    public Polygon Clipper() => PolygonClipper.Union(this.subject, this.clipping);
+    public Polygon PolygonClipper() => global::PolygonClipper.PolygonClipper.Union(this.subject, this.clipping);
 
     [Benchmark(Baseline = true)]
     public PathsD Clipper2()
@@ -46,109 +56,5 @@ public class ClippingLibraryComparison
         clipper2.AddClip(this.clipping2);
         clipper2.Execute(ClipType.Union, FillRule.Positive, solution);
         return solution;
-    }
-
-    public static (Polygon Subject, Polygon Clipping) BuildPolygon()
-    {
-        IGeometryObject subjectGeometry = Data.Features[0].Geometry;
-        IGeometryObject clippingGeometry = Data.Features[1].Geometry;
-
-        Polygon subject = ConvertToPolygon(subjectGeometry);
-        Polygon clipping = ConvertToPolygon(clippingGeometry);
-
-        return (subject, clipping);
-    }
-
-    public static (PathsD Subject, PathsD Clipping) BuildPolygon2()
-    {
-        IGeometryObject subjectGeometry = Data.Features[0].Geometry;
-        IGeometryObject clippingGeometry = Data.Features[1].Geometry;
-
-        PathsD subject = ConvertToPolygon2(subjectGeometry);
-        PathsD clipping = ConvertToPolygon2(clippingGeometry);
-
-        return (subject, clipping);
-    }
-
-    private static Polygon ConvertToPolygon(IGeometryObject geometry)
-    {
-        if (geometry is GeoPolygon geoJsonPolygon)
-        {
-            // Convert GeoJSON Polygon to our Polygon type
-            Polygon polygon = new();
-            foreach (LineString ring in geoJsonPolygon.Coordinates)
-            {
-                Contour contour = new();
-                foreach (IPosition xy in ring.Coordinates)
-                {
-                    contour.AddVertex(new Vertex(xy.Longitude, xy.Latitude));
-                }
-                polygon.Push(contour);
-            }
-
-            return polygon;
-        }
-        else if (geometry is MultiPolygon geoJsonMultiPolygon)
-        {
-            // Convert GeoJSON MultiPolygon to our Polygon type
-            Polygon polygon = new();
-            foreach (GeoPolygon geoPolygon in geoJsonMultiPolygon.Coordinates)
-            {
-                foreach (LineString ring in geoPolygon.Coordinates)
-                {
-                    Contour contour = new();
-                    foreach (IPosition xy in ring.Coordinates)
-                    {
-                        contour.AddVertex(new Vertex(xy.Longitude, xy.Latitude));
-                    }
-                    polygon.Push(contour);
-                }
-            }
-
-            return polygon;
-        }
-
-        throw new InvalidOperationException("Unsupported geometry type.");
-    }
-
-    private static PathsD ConvertToPolygon2(IGeometryObject geometry)
-    {
-        if (geometry is GeoPolygon geoJsonPolygon)
-        {
-            // Convert GeoJSON Polygon to our Polygon type
-            PathsD polygon = [];
-            foreach (LineString ring in geoJsonPolygon.Coordinates)
-            {
-                PathD contour = [];
-                foreach (IPosition xy in ring.Coordinates)
-                {
-                    contour.Add(new PointD(xy.Longitude, xy.Latitude));
-                }
-                polygon.Add(contour);
-            }
-
-            return polygon;
-        }
-        else if (geometry is MultiPolygon geoJsonMultiPolygon)
-        {
-            // Convert GeoJSON MultiPolygon to our Polygon type
-            PathsD polygon = [];
-            foreach (GeoPolygon geoPolygon in geoJsonMultiPolygon.Coordinates)
-            {
-                foreach (LineString ring in geoPolygon.Coordinates)
-                {
-                    PathD contour = [];
-                    foreach (IPosition xy in ring.Coordinates)
-                    {
-                        contour.Add(new PointD(xy.Longitude, xy.Latitude));
-                    }
-                    polygon.Add(contour);
-                }
-            }
-
-            return polygon;
-        }
-
-        throw new InvalidOperationException("Unsupported geometry type.");
     }
 }

--- a/tests/PolygonClipper.Benchmarks/PolygonClipper.Benchmarks.csproj
+++ b/tests/PolygonClipper.Benchmarks/PolygonClipper.Benchmarks.csproj
@@ -31,11 +31,12 @@
   <ItemGroup>
     <Compile Include="..\PolygonClipper.Tests\TestData.cs" Link="TestData.cs" />
     <Compile Include="..\PolygonClipper.Tests\TestEnvironment.cs" Link="TestEnvironment.cs" />
+    <Compile Include="..\PolygonClipper.Tests\TestPolygonUtilities.cs" Link="TestPolygonUtilities.cs" />    
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
-    <PackageReference Include="Clipper2" Version="1.4.0" />
+    <PackageReference Include="Clipper2" Version="1.5.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/PolygonClipper.Tests/GenericTestCases.cs
+++ b/tests/PolygonClipper.Tests/GenericTestCases.cs
@@ -54,7 +54,7 @@ public class GenericTestCases
         Polygon clipping = ConvertToPolygon(clippingGeometry);
 
 #pragma warning disable RCS1124 // Inline local variable
-        List<ExpectedResult> expectedResults = ExtractExpectedResults(data.Features.Skip(2).ToList(), data.Type);
+        List<ExpectedResult> expectedResults = ExtractExpectedResults([.. data.Features.Skip(2)], data.Type);
 #pragma warning restore RCS1124 // Inline local variable
 
         // ExpectedResult result = expectedResults[1];
@@ -157,7 +157,8 @@ public class GenericTestCases
 
             return new ExpectedResult
             {
-                Operation = operation, Coordinates = ConvertToPolygon(feature.Geometry as MultiPolygon)
+                Operation = operation,
+                Coordinates = ConvertToPolygon(feature.Geometry as MultiPolygon)
             };
         });
 

--- a/tests/PolygonClipper.Tests/PolygonClipper.Tests.csproj
+++ b/tests/PolygonClipper.Tests/PolygonClipper.Tests.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="coverlet.collector" Version="1.2.0" />
+    <PackageReference Include="Clipper2" Version="1.5.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/PolygonClipper.Tests/TestData.cs
+++ b/tests/PolygonClipper.Tests/TestData.cs
@@ -13,7 +13,7 @@ internal static class TestData
     public static class Fixtures
     {
         public static FeatureCollection GetFeatureCollection(string fileName)
-            => JsonSerializer.Deserialize<FeatureCollection>(GetGeoJsonPath(fileName));
+            => JsonSerializer.Deserialize<FeatureCollection>(GetGeoJsonPath(fileName))!;
 
         private static string GetGeoJsonPath(string fileName)
             => GetFullPath(nameof(Fixtures), fileName);
@@ -33,7 +33,7 @@ internal static class TestData
         public static FeatureCollection GetFeatureCollection(string fileName)
         {
             string path = GetGeoJsonPath(fileName);
-            return JsonSerializer.Deserialize<FeatureCollection>(File.ReadAllText(path));
+            return JsonSerializer.Deserialize<FeatureCollection>(File.ReadAllText(path))!;
         }
 
         private static string GetGeoJsonPath(string fileName)

--- a/tests/PolygonClipper.Tests/TestPolygonUtilities.cs
+++ b/tests/PolygonClipper.Tests/TestPolygonUtilities.cs
@@ -1,0 +1,125 @@
+// Copyright (c) Six Labors.
+// Licensed under the Six Labors Split License.
+
+using System;
+using Clipper2Lib;
+using GeoJSON.Text.Feature;
+using GeoJSON.Text.Geometry;
+
+using GeoPolygon = GeoJSON.Text.Geometry.Polygon;
+
+namespace PolygonClipper.Tests;
+
+internal static class TestPolygonUtilities
+{
+    public static (Polygon Subject, Polygon Clipping) BuildPolygon(FeatureCollection data)
+    {
+        IGeometryObject subjectGeometry = data.Features[0].Geometry;
+        IGeometryObject clippingGeometry = data.Features[1].Geometry;
+
+        Polygon subject = ConvertToPolygon(subjectGeometry);
+        Polygon clipping = ConvertToPolygon(clippingGeometry);
+
+        return (subject, clipping);
+    }
+
+    public static (PathsD Subject, PathsD Clipping) BuildClipper2Polygon(FeatureCollection data)
+    {
+        IGeometryObject subjectGeometry = data.Features[0].Geometry;
+        IGeometryObject clippingGeometry = data.Features[1].Geometry;
+
+        PathsD subject = ConvertToClipper2Polygon(subjectGeometry);
+        PathsD clipping = ConvertToClipper2Polygon(clippingGeometry);
+
+        return (subject, clipping);
+    }
+
+    private static Polygon ConvertToPolygon(IGeometryObject geometry)
+    {
+        if (geometry is GeoPolygon geoJsonPolygon)
+        {
+            // Convert GeoJSON Polygon to our Polygon type
+            Polygon polygon = new();
+            foreach (LineString ring in geoJsonPolygon.Coordinates)
+            {
+                Contour contour = new();
+                foreach (IPosition xy in ring.Coordinates)
+                {
+                    contour.AddVertex(new Vertex(xy.Longitude, xy.Latitude));
+                }
+
+                polygon.Push(contour);
+
+                if (!ring.IsClosed())
+                {
+                    contour.AddVertex(contour.GetVertex(0));
+                }
+            }
+
+            return polygon;
+        }
+        else if (geometry is MultiPolygon geoJsonMultiPolygon)
+        {
+            // Convert GeoJSON MultiPolygon to our Polygon type
+            Polygon polygon = new();
+            foreach (GeoPolygon geoPolygon in geoJsonMultiPolygon.Coordinates)
+            {
+                foreach (LineString ring in geoPolygon.Coordinates)
+                {
+                    Contour contour = new();
+                    foreach (IPosition xy in ring.Coordinates)
+                    {
+                        contour.AddVertex(new Vertex(xy.Longitude, xy.Latitude));
+                    }
+
+                    polygon.Push(contour);
+                }
+            }
+
+            return polygon;
+        }
+
+        throw new InvalidOperationException("Unsupported geometry type.");
+    }
+
+    private static PathsD ConvertToClipper2Polygon(IGeometryObject geometry)
+    {
+        if (geometry is GeoPolygon geoJsonPolygon)
+        {
+            // Convert GeoJSON Polygon to our Polygon type
+            PathsD polygon = [];
+            foreach (LineString ring in geoJsonPolygon.Coordinates)
+            {
+                PathD contour = [];
+                foreach (IPosition xy in ring.Coordinates)
+                {
+                    contour.Add(new PointD(xy.Longitude, xy.Latitude));
+                }
+                polygon.Add(contour);
+            }
+
+            return polygon;
+        }
+        else if (geometry is MultiPolygon geoJsonMultiPolygon)
+        {
+            // Convert GeoJSON MultiPolygon to our Polygon type
+            PathsD polygon = [];
+            foreach (GeoPolygon geoPolygon in geoJsonMultiPolygon.Coordinates)
+            {
+                foreach (LineString ring in geoPolygon.Coordinates)
+                {
+                    PathD contour = [];
+                    foreach (IPosition xy in ring.Coordinates)
+                    {
+                        contour.Add(new PointD(xy.Longitude, xy.Latitude));
+                    }
+                    polygon.Add(contour);
+                }
+            }
+
+            return polygon;
+        }
+
+        throw new InvalidOperationException("Unsupported geometry type.");
+    }
+}

--- a/tests/PolygonClipper.Tests/TestPolygonUtilitiesTests.cs
+++ b/tests/PolygonClipper.Tests/TestPolygonUtilitiesTests.cs
@@ -1,0 +1,80 @@
+// Copyright (c) Six Labors.
+// Licensed under the Six Labors Split License.
+
+using Clipper2Lib;
+using GeoJSON.Text.Feature;
+using PolygonClipper.Tests.TestCases;
+using Xunit;
+
+namespace PolygonClipper.Tests;
+public class TestPolygonUtilitiesTests
+{
+    private static readonly FeatureCollection Data = TestData.Generic.GetFeatureCollection("issue71.geojson");
+
+    [Fact]
+    public void ConvertToPolygon_ValidGeometry_ReturnsPolygon()
+    {
+        (Polygon subject, Polygon clipping) = TestPolygonUtilities.BuildPolygon(Data);
+
+        Assert.NotNull(subject);
+        Assert.NotNull(clipping);
+        Assert.IsType<Polygon>(subject);
+        Assert.IsType<Polygon>(clipping);
+
+        Assert.Equal(2, subject.ContourCount);
+        Assert.Equal(122, subject[0].VertexCount);
+        Assert.Equal(9, subject[1].VertexCount);
+
+        Assert.Equal(1, clipping.ContourCount);
+        Assert.Equal(12, clipping[0].VertexCount);
+    }
+
+    [Fact]
+    public void ConvertToClipper2Polygon_ValidGeometry_ReturnsPathsD()
+    {
+        (PathsD subject, PathsD clipping) = TestPolygonUtilities.BuildClipper2Polygon(Data);
+
+        Assert.NotNull(subject);
+        Assert.NotNull(clipping);
+        Assert.IsType<PathsD>(subject);
+        Assert.IsType<PathsD>(clipping);
+
+        Assert.Equal(2, subject.Count);
+        Assert.Equal(122, subject[0].Count);
+        Assert.Equal(9, subject[1].Count);
+
+        Assert.Single(clipping);
+        Assert.Equal(12, clipping[0].Count);
+    }
+
+    [Fact]
+    public void PolygonClipper_Union_ValidPolygons_ReturnsCorrectResult()
+    {
+        (Polygon subject, Polygon clipping) = TestPolygonUtilities.BuildPolygon(Data);
+
+        Polygon solution = PolygonClipper.Union(subject, clipping);
+        Assert.NotNull(solution);
+
+        Assert.Equal(2, solution.ContourCount);
+        Assert.Equal(122, solution[0].VertexCount);
+        Assert.Equal(9, solution[1].VertexCount);
+    }
+
+    [Fact(Skip = "Clipper2 result is unverified.")]
+    public void Clipper2_Union_ValidPolygons_ReturnsCorrectResult()
+    {
+        (PathsD subject, PathsD clipping) = TestPolygonUtilities.BuildClipper2Polygon(Data);
+
+        PathsD solution = [];
+        ClipperD clipper2 = new();
+        clipper2.AddSubject(subject);
+        clipper2.AddClip(clipping);
+        Assert.True(clipper2.Execute(ClipType.Union, FillRule.Positive, solution));
+
+        // Clipper2 is wrong?
+        // It only produces a single polygon with 121 vertices instead of two polygons.
+        Assert.Equal(2, solution.Count);
+        Assert.Equal(122, solution[0].Count);
+        Assert.Equal(9, solution[1].Count);
+    }
+}


### PR DESCRIPTION
A rework of #12 and #13 with added unsafe code!

Note: I've discovered that Clipper2 does not return the correct result for the test data so pay attention to our own results only.

CC @stefannikolei 

```
BenchmarkDotNet v0.14.0, Windows 11 (10.0.26100.4652)
11th Gen Intel Core i7-11370H 3.30GHz, 1 CPU, 8 logical and 4 physical cores
.NET SDK 9.0.302
  [Host]     : .NET 9.0.7 (9.0.725.31616), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI
  DefaultJob : .NET 9.0.7 (9.0.725.31616), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI
```
Main

| Method   | Mean     | Error    | StdDev   | Ratio | RatioSD | Gen0   | Gen1   | Allocated | Alloc Ratio |
|--------- |---------:|---------:|---------:|------:|--------:|-------:|-------:|----------:|------------:|
| Clipper  | 48.65 us | 0.501 us | 0.444 us |  2.90 |    0.03 | 7.8125 | 0.9155 |  47.87 KB |        1.50 |
| Clipper2 | 16.78 us | 0.151 us | 0.118 us |  1.00 |    0.01 | 5.1880 | 0.3357 |  31.84 KB |        1.00 |

PR (PossibleIntersection)

| Method         | Mean     | Error    | StdDev   | Ratio | RatioSD | Gen0   | Gen1   | Allocated | Alloc Ratio |
|--------------- |---------:|---------:|---------:|------:|--------:|-------:|-------:|----------:|------------:|
| PolygonClipper | 47.07 us | 0.467 us | 0.414 us |  2.73 |    0.03 | 7.6904 | 0.6714 |  47.23 KB |        1.48 |
| Clipper2       | 17.25 us | 0.160 us | 0.150 us |  1.00 |    0.01 | 5.1880 | 0.3357 |  31.84 KB |        1.00 |

PR (StablePriorityQueue)

| Method         | Mean     | Error    | StdDev   | Ratio | RatioSD | Gen0   | Gen1   | Allocated | Alloc Ratio |
|--------------- |---------:|---------:|---------:|------:|--------:|-------:|-------:|----------:|------------:|
| PolygonClipper | 44.23 us | 0.246 us | 0.218 us |  2.60 |    0.02 | 6.7139 | 0.4883 |  41.34 KB |        1.30 |
| Clipper2       | 16.99 us | 0.157 us | 0.139 us |  1.00 |    0.01 | 5.1880 | 0.3357 |  31.84 KB |        1.00 |