### PR TITLE
Fix output record paths to avoid tombstone reuse

### DIFF
--- a/src/PolygonClipper/VertexPoolList.cs
+++ b/src/PolygonClipper/VertexPoolList.cs
@@ -101,6 +101,7 @@ internal sealed class OutputRecordPoolList : PooledList<OutputRecord>
             outputRecord.BackEdge = null;
             outputRecord.Points = null;
             outputRecord.Bounds = default;
+            outputRecord.Path = outputRecord.Path == Tombstone ? [] : outputRecord.Path;
             outputRecord.Path.Clear();
             outputRecord.Splits?.Clear();
             outputRecord.RecursiveSplit = null;


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/PolygonClipper/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
This pull request makes a minor update to the `Add` method in `VertexPoolList.cs` to ensure the `Path` property of `outputRecord` is properly initialized before it is cleared. This helps prevent potential null reference issues.

* Ensures `outputRecord.Path` is set to an empty list if it has the special `Tombstone` value before calling `Clear()` on it.
<!-- Thanks for contributing to PolygonClipper! -->
